### PR TITLE
Fix embedded translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ __formats__:
 I18n.translate("__formats__.date.day_names", iter: 2) "Tuesday"
 ```
 
+### Embedding translations inside your binary
+
+You can embed translations inside your binary by using the following macro call:
+
+```crystal
+I18n::Backend::Yaml.embed(["some/locale/directory", "some/other/locale/directory"])
+```
+
 ## Development
 
 TODO :

--- a/src/i18n/backend/yaml_embed.cr
+++ b/src/i18n/backend/yaml_embed.cr
@@ -15,6 +15,6 @@ files = Dir.glob "#{dir}/*.yml" do |file|
   puts "lang_data = ::YAML.parse <<-I18nENDTOKEN"
   puts content
   puts "I18nENDTOKEN"
-  puts "backend.translations[\"#{lang}\"] = I18n::Backend::Yaml.normalize(lang_data.as_h)"
+  puts "backend.translations[\"#{lang}\"] = I18n::Backend::Yaml.normalize(lang_data)"
   puts "backend.available_locales << \"#{lang}\""
 end


### PR DESCRIPTION
The PR upgrading to 0.25.0 broke the embedding, more specifically [this line](https://github.com/TechMagister/i18n.cr/pull/6/files#diff-39b75889b339b981082045f2176afb26R186) (moving `as_h` into the `#normalize` method).

This fixes it. Would be great to have some tests to prevent this part from being neglected by future upgrades, though I couldn't really think of the best way to test the macro. Maybe something like `Process.run` on `yaml_embed.cr` only, while capturing `STDOUT`. But I couldn't get this to work properly.

I also added the feature to the README because I think it's quite useful. Back when I started using this shard it took me a while to figure out that my release binary requires the locale files and also that I can actually enable embedding and not have to ship the locale files with the binary.

Also, thanks for the work you put into this :pizza: :beer: 