### PR TITLE
Annotate return types of abstract methods

### DIFF
--- a/src/i18n/backend/yaml.cr
+++ b/src/i18n/backend/yaml.cr
@@ -7,7 +7,7 @@ module I18n
     class Yaml < I18n::Backend::Base
       EMPTY_HASH = {} of String => String
 
-      getter available_locales
+      getter available_locales : Array(String)
       property translations
 
       @translations = Hash(String, Hash(String, YAML::Any)).new


### PR DESCRIPTION
This is needed to upgrade to Crystal v0.30.0 with no warnings